### PR TITLE
Normalize PAE input handling for flexible format support

### DIFF
--- a/py2Dmol/viewer.py
+++ b/py2Dmol/viewer.py
@@ -1917,6 +1917,23 @@ window.py2dmol_configs['{viewer_id}'] = {json.dumps(self.config)};
                                   "rainbow", "auto", "entropy", "deepmind") or a literal color (e.g., "red", "#ff0000").
         """
 
+        # Normalize paes: accept a single 2D matrix in addition to a list of matrices.
+        # Distinguishes by checking the depth of nesting:
+        #   paes=matrix        (ndarray/list-of-lists, ndim==2) → wrap as [matrix]
+        #   paes=[m1, m2, ...] (list of 2D matrices, ndim==3)   → keep as-is
+        if paes is not None:
+            try:
+                paes_arr = np.asarray(paes, dtype=float)
+                if paes_arr.ndim == 2:
+                    paes = [paes_arr]
+                elif paes_arr.ndim == 3:
+                    paes = [paes_arr[i] for i in range(paes_arr.shape[0])]
+                # ndim 1 or other: leave as-is; _update will warn when it gets there
+            except (ValueError, TypeError):
+                # Jagged / mixed-size matrices (different chain counts per model).
+                # Try element-wise conversion so each entry becomes a 2D numpy array.
+                paes = [np.asarray(m, dtype=float) for m in paes]
+
         # Allow passing a 4-letter PDB code directly; fetch if local file is missing
         if isinstance(filepath, str) and len(filepath) == 4 and filepath.isalnum() and not os.path.exists(filepath):
             resolved = self._get_filepath_from_pdb_id(filepath)

--- a/py2Dmol/viewer.py
+++ b/py2Dmol/viewer.py
@@ -513,7 +513,21 @@ class view:
       self._plddts = plddts
       self._chains = chains
       self._position_types = position_types
-      self._pae = pae
+
+      # Normalize PAE to a 2D numpy float array so arithmetic in _get_data_dict
+      # works correctly regardless of whether the caller passed a list-of-lists,
+      # a plain list, or an ndarray.
+      if pae is not None:
+          pae_arr = np.asarray(pae, dtype=float)
+          if pae_arr.ndim == 2:
+              self._pae = pae_arr
+          else:
+              print(f"Warning: PAE must be a 2D matrix, got shape {pae_arr.shape}. "
+                    "Did you pass `paes=data['pae']` instead of `paes=[data['pae']]`? Ignoring PAE.")
+              self._pae = None
+      else:
+          self._pae = None
+
       self._scatter = scatter
       self._position_names = position_names
       self._position_residue_numbers = residue_numbers


### PR DESCRIPTION
## Summary
This PR improves the handling of Predicted Aligned Error (PAE) matrices by normalizing input formats and providing better validation and user feedback.

## Key Changes
- **PAE normalization in `_update` method**: Added logic to convert PAE input to a 2D numpy float array, ensuring consistent internal representation regardless of input format (list-of-lists, plain list, or ndarray)
- **PAE validation**: Added dimension checking to ensure PAE is 2D; if not, a warning is printed and PAE is ignored
- **PAE preprocessing in `add_pdb` method**: Added intelligent preprocessing to handle both single PAE matrices and lists of PAE matrices:
  - Detects 2D matrices and wraps them as `[matrix]` for single-structure cases
  - Handles 3D arrays (multiple matrices) by converting to list format
  - Gracefully handles jagged/mixed-size matrices by converting each element individually
  - Provides helpful error handling for invalid formats

## Implementation Details
- Uses `np.asarray()` with `dtype=float` for consistent type conversion
- Checks `ndim` property to distinguish between single matrices (2D) and multiple matrices (3D)
- Includes user-friendly warning message suggesting common mistakes (e.g., passing `paes=data['pae']` instead of `paes=[data['pae']]`)
- Maintains backward compatibility while accepting more flexible input formats

https://claude.ai/code/session_011WjAoV48PBEZioQwtUynhY